### PR TITLE
fixed iterative LinearLSTriangulation

### DIFF
--- a/Chapter4_StructureFromMotion/Triangulation.cpp
+++ b/Chapter4_StructureFromMotion/Triangulation.cpp
@@ -73,9 +73,11 @@ Mat_<double> IterativeLinearLSTriangulation(Point3d u,	//homogenous image point 
 											) {
 	double wi = 1, wi1 = 1;
 	Mat_<double> X(4,1); 
-	for (int i=0; i<10; i++) { //Hartley suggests 10 iterations at most
-		Mat_<double> X_ = LinearLSTriangulation(u,P,u1,P1);
-		X(0) = X_(0); X(1) = X_(1); X(2) = X_(2); X(3) = 1.0;
+
+	Mat_<double> X_ = LinearLSTriangulation(u,P,u1,P1);
+	X(0) = X_(0); X(1) = X_(1); X(2) = X_(2); X(3) = 1.0;
+
+	for (int i=0; i<10; i++) { //Hartley suggests 10 iterations at most		
 		
 		//recalculate weights
 		double p2x = Mat_<double>(Mat_<double>(P).row(2)*X)(0);


### PR DESCRIPTION
I basically just moved the first 2 instructions of the loop outside of it. They were always resetting the newly calculated value to the initial values, so that the loop just stopped after the first iteration.