### PR TITLE
Check that the return value is nil before attempting to do anything with...

### DIFF
--- a/Chapter2_iPhoneAR/Example_MarkerBasedAR/Example_MarkerBasedAR/VideoSource.mm
+++ b/Chapter2_iPhoneAR/Example_MarkerBasedAR/Example_MarkerBasedAR/VideoSource.mm
@@ -146,7 +146,7 @@
         AVCaptureDeviceInput *videoIn = [AVCaptureDeviceInput deviceInputWithDevice:videoDevice error:&error];
         self.deviceInput = videoIn;
         
-        if (!error)
+        if (nil != videoIn)
         {
             if ([[self captureSession] canAddInput:videoIn])
             {
@@ -160,7 +160,7 @@
         }
         else
         {
-            NSLog(@"Couldn't create video input");
+    		NSLog(@"Couldn't create video input: %@", [error localizedDescription]);
             return FALSE;
         }
     }


### PR DESCRIPTION
... the NSError object

Apple's Error Handling Programming Guide
(https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/
ErrorHandlingCocoa/CreateCustomizeNSError/CreateCustomizeNSError.html)
states that return values must be checked for nil or NO before
attempting to do anything with the NSError object
