### PR TITLE
Resolve compile error for windows

### DIFF
--- a/Chapter4_StructureFromMotion/Common.cpp
+++ b/Chapter4_StructureFromMotion/Common.cpp
@@ -17,6 +17,8 @@
 
 #ifndef WIN32
 #include <dirent.h>
+#else
+#include <windows.h>
 #endif
 
 using namespace std;


### PR DESCRIPTION
## Resolve compile error for windows

Original code didn't include `<windows.h>` and this made compile error when using only few code snippets.
